### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/db_backup.yaml
+++ b/.github/workflows/db_backup.yaml
@@ -28,7 +28,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
       - name: Upload backup
-        uses: BetaHuhn/do-spaces-action@v2.0.70
+        uses: BetaHuhn/do-spaces-action@v2.0.74
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -56,13 +56,13 @@ jobs:
           python-version: "3.10"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.npm
           key: npm
@@ -75,7 +75,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Use yarn cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
@@ -83,14 +83,14 @@ jobs:
             yarn-
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.cache/pip
           key: pip
 
       # Need to use this because yarn cache is not working properly
       - name: Use node_modules cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}
@@ -98,7 +98,7 @@ jobs:
             node_modules-
 
       - name: Use venv cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: venv
           key: venv-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
@@ -120,7 +120,7 @@ jobs:
         run: make collectstatic
 
       - name: Upload static files
-        uses: BetaHuhn/do-spaces-action@v2.0.70
+        uses: BetaHuhn/do-spaces-action@v2.0.74
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}

--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -16,19 +16,19 @@ jobs:
           python-version: "3.10"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.4.1
+        uses: actions/setup-node@v3.5.0
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.npm
           key: npm
 
       - name: Use node_modules cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('package-test.json') }}
@@ -36,13 +36,13 @@ jobs:
             node_modules-
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: ~/.cache/pip
           key: pip
 
       - name: Use tox cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         with:
           path: .tox
           key: tox-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
@@ -68,4 +68,4 @@ jobs:
         run: make test
 
       - name: Run codecov
-        uses: codecov/codecov-action@v3.1.0
+        uses: codecov/codecov-action@v3.1.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release [v3.1.1](https://github.com/codecov/codecov-action/releases/tag/v3.1.1) on 2022-09-19T15:25:54Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release [v3.5.0](https://github.com/actions/setup-node/releases/tag/v3.5.0) on 2022-09-27T13:40:45Z
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release [v2.0.74](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.74) on 2022-09-26T02:57:24Z
* **[actions/cache](https://github.com/actions/cache)** published a new release [v3.0.9](https://github.com/actions/cache/releases/tag/v3.0.9) on 2022-09-30T05:19:40Z
