### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/db_backup.yaml
+++ b/.github/workflows/db_backup.yaml
@@ -16,7 +16,7 @@ jobs:
       SPACE_NAME: scrap-db-backups
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - uses: szenius/set-timezone@v1.1
         with:
@@ -28,7 +28,7 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
       - name: Upload backup
-        uses: BetaHuhn/do-spaces-action@v2.0.84
+        uses: BetaHuhn/do-spaces-action@v2.0.96
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -21,7 +21,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.2.1
+        uses: docker/setup-buildx-action@v2.4.1
 
       - name: Login to GitHub registry
         uses: docker/login-action@v2.1.0
@@ -31,7 +31,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push docker image
-        uses: docker/build-push-action@v3.2.0
+        uses: docker/build-push-action@v4.0.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
@@ -48,21 +48,21 @@ jobs:
       SPACE_NAME: cdn.githubcontrib.samarchyan.me
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.10"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ~/.npm
           key: npm
@@ -75,7 +75,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> "${GITHUB_OUTPUT}"
 
       - name: Use yarn cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: yarn-${{ hashFiles('yarn.lock') }}
@@ -83,14 +83,14 @@ jobs:
             yarn-
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ~/.cache/pip
           key: pip
 
       # Need to use this because yarn cache is not working properly
       - name: Use node_modules cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('yarn.lock') }}
@@ -98,7 +98,7 @@ jobs:
             node_modules-
 
       - name: Use venv cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: venv
           key: venv-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}
@@ -120,7 +120,7 @@ jobs:
         run: make collectstatic
 
       - name: Upload static files
-        uses: BetaHuhn/do-spaces-action@v2.0.84
+        uses: BetaHuhn/do-spaces-action@v2.0.96
         with:
           access_key: ${{ secrets.SPACES_ACCESS_KEY }}
           secret_key: ${{ secrets.SPACES_SECRET_KEY }}
@@ -129,7 +129,7 @@ jobs:
           source: static
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2.2.0
+        uses: digitalocean/action-doctl@v2.3.0
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -151,10 +151,10 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/destruction.yaml
+++ b/.github/workflows/destruction.yaml
@@ -11,10 +11,10 @@ jobs:
       PROJECT: githubcontrib
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/reusable_restart_app.yaml
+++ b/.github/workflows/reusable_restart_app.yaml
@@ -10,10 +10,10 @@ jobs:
       PROJECT: githubcontrib
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -8,27 +8,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v4.5.0
         with:
           python-version: "3.10"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: 18.x
           registry-url: https://registry.npmjs.org
 
       - name: Use npm cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ~/.npm
           key: npm
 
       - name: Use node_modules cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('package-test.json') }}
@@ -36,13 +36,13 @@ jobs:
             node_modules-
 
       - name: Use pip cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: ~/.cache/pip
           key: pip
 
       - name: Use tox cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.2.6
         with:
           path: .tox
           key: tox-${{ hashFiles('requirements.txt', 'requirements-dev.txt') }}

--- a/.github/workflows/update_avatars.yaml
+++ b/.github/workflows/update_avatars.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |

--- a/.github/workflows/update_github_actions.yaml
+++ b/.github/workflows/update_github_actions.yaml
@@ -15,7 +15,7 @@ jobs:
       COMMITTER_EMAIL: desecho@gmail.com
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
         with:
           # Access token with `workflow` scope is required
           token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}

--- a/.github/workflows/update_stars.yaml
+++ b/.github/workflows/update_stars.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.3.0
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3.0
+        uses: azure/setup-kubectl@v3.2
 
       - name: Configure kubectl
         run: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.2.6](https://github.com/actions/cache/releases/tag/v3.2.6)** on 2023-02-21T10:18:08Z
* **[digitalocean/action-doctl](https://github.com/digitalocean/action-doctl)** published a new release **[v2.3.0](https://github.com/digitalocean/action-doctl/releases/tag/v2.3.0)** on 2022-12-23T15:41:05Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.4.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.4.1)** on 2023-02-06T12:17:14Z
* **[azure/setup-kubectl](https://github.com/azure/setup-kubectl)** published a new release **[v3.2](https://github.com/Azure/setup-kubectl/releases/tag/v3.2)** on 2023-01-09T19:06:13Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.5.0](https://github.com/actions/setup-python/releases/tag/v4.5.0)** on 2023-01-12T11:29:27Z
* **[BetaHuhn/do-spaces-action](https://github.com/BetaHuhn/do-spaces-action)** published a new release **[v2.0.96](https://github.com/BetaHuhn/do-spaces-action/releases/tag/v2.0.96)** on 2023-02-27T01:47:39Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v3.6.0](https://github.com/actions/setup-node/releases/tag/v3.6.0)** on 2023-01-05T14:09:37Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v4.0.0](https://github.com/docker/build-push-action/releases/tag/v4.0.0)** on 2023-01-30T18:26:38Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
